### PR TITLE
Add textContentType to formField

### DIFF
--- a/src/ComposableForm/ComposableForm.tsx
+++ b/src/ComposableForm/ComposableForm.tsx
@@ -610,6 +610,7 @@ const ComposableForm = <T extends ComposableItem>(
         errorMessageColor={getComposableFormOptions().textFields.errorMessageColor}
         value={model[field.id] as string | undefined}
         editable={!field.disabled && !(loadingMapper && loadingMapper[field.id])}
+        textContentType={field.textContentType || (field.isPassword ? 'password' : undefined)}
         multiline={field.multiline}
         maxLength={field.maxLength}
         scrollEnabled={false} // fix for trigger scroll on iOS when keyboard opens

--- a/src/models/formField.ts
+++ b/src/models/formField.ts
@@ -1,5 +1,5 @@
-import { ComposableItem } from './composableItem';
 import { ReturnKeyTypeOptions } from 'react-native';
+import { ComposableItem } from './composableItem';
 
 export type FormField = {
   id: string;
@@ -28,6 +28,7 @@ export type FormField = {
   disabled?: boolean;
   multiline?: boolean;
   isPassword?: boolean;
+  textContentType?: 'none' | 'URL' | 'addressCity' | 'addressCityAndState' | 'addressState' | 'countryName' | 'creditCardNumber' | 'emailAddress' | 'familyName' | 'fullStreetAddress' | 'givenName' | 'jobTitle' | 'location' | 'middleName' | 'name' | 'namePrefix' | 'nameSuffix' | 'nickname' | 'organizationName' | 'postalCode' | 'streetAddressLine1' | 'streetAddressLine2' | 'sublocality' | 'telephoneNumber' | 'username' | 'password' | 'newPassword' | 'oneTimeCode';
   maxLength?: number;
   keyboard?: 'email-address' | 'default';
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';


### PR DESCRIPTION
This field is used to specify to Android/iOS what kind of text field we are using.
Is also used by password managers to allow the autofill of username and password.